### PR TITLE
Custom bootstrap template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Note:
 * first\_boot will automatically get 'fqdn' set to 'node\_name'
 * The bootstrap server is set automatically from the Chef endpoint
 * Node names are trimmed of leading and trailing whitespace
+* A custom bootstrap template can be specified by using `boostrap_file: 'path_to_bootstrap_file'` in `ChefProvisioner::Bootstrap.generate`

--- a/lib/chef-provisioner/bootstrap.rb
+++ b/lib/chef-provisioner/bootstrap.rb
@@ -7,9 +7,12 @@ module ChefProvisioner
   # Help render the bootstrap script
   module Bootstrap
     extend self
-    BOOTSTRAP_TEMPLATE = File.read(File.expand_path('../templates/bootstrap.erb', __FILE__)).freeze
+    def bootstrap_template
+      @bootstrap_template ||= File.read(File.expand_path(@bootstrap_file, __FILE__))
+    end
 
-    def generate(node_name: '', chef_version: '12.4.1', environment: nil, server: '', first_boot: {}, reinstall: false, audit: false, force: false, retries: 1, profile: false, chef_cmd: nil)
+    def generate(node_name: '', chef_version: '12.4.1', environment: nil, server: '', first_boot: {}, reinstall: false, audit: false, force: false, retries: 1, profile: false, chef_cmd: nil, bootstrap_file: nil)
+      bootstrap_file.nil? ? @bootstrap_file = '../templates/bootstrap.erb' : @bootstrap_file = "#{Dir.pwd}/#{bootstrap_file}"
       node_name = node_name.strip
       server = ChefAPI.endpoint if server.empty?
       run_list = first_boot[:run_list] if first_boot[:run_list] # FIXME - symbolize keys instead of the dup here
@@ -22,7 +25,7 @@ module ChefProvisioner
     private
 
     def render(**kwargs)
-      ERB.new(BOOTSTRAP_TEMPLATE).result(OpenStruct.new(**kwargs).instance_eval { binding })
+      ERB.new(bootstrap_template).result(OpenStruct.new(**kwargs).instance_eval { binding })
     end
 
     def get_client_key(node_name, environment, run_list, force, retries)

--- a/spec/fixtures/bare_bootstrap.txt
+++ b/spec/fixtures/bare_bootstrap.txt
@@ -19,7 +19,7 @@ log_level        :info
 log_location     STDOUT
 ssl_verify_mode  :verify_peer
 environment      "default"
-chef_server_url  "localhost"
+chef_server_url  "127.0.0.1"
 node_name ""
 EOF
 


### PR DESCRIPTION
- allows a custom bootstrap template to be used instead of the one included
- changed chef_zero endpoint to 127.0.0.1 from localhost
