### PR TITLE
raise exception if client_pem is empty after all attempts

### DIFF
--- a/lib/chef-provisioner/bootstrap.rb
+++ b/lib/chef-provisioner/bootstrap.rb
@@ -33,6 +33,7 @@ module ChefProvisioner
         attempts += 1
         sleep(5)
       end
+      raise "Unable to get client key. Chef init failed." if client_pem.empty?
       client_pem
     end
   end


### PR DESCRIPTION
@dalehamel This will raise an exception if the client key is still empty after all the attempts. Without this, the bootstrap will continue but fail (silently) as soon as it tries to run chef.

cc: @dturn
